### PR TITLE
uri2fsn: Handle a subset of legacy UNC file URIs

### DIFF
--- a/senf/_fsnative.py
+++ b/senf/_fsnative.py
@@ -533,12 +533,12 @@ def uri2fsn(uri):
     parsed = urlparse(uri)
     scheme = parsed.scheme
     netloc = parsed.netloc
-    path = parsed.path
+    parsed_path = parsed.path
 
     if scheme != "file":
         raise ValueError("Not a file URI: %r" % uri)
 
-    if not path:
+    if not parsed_path:
         raise ValueError("Invalid file URI: %r" % uri)
 
     uri = urlunparse(parsed)[7:]
@@ -556,7 +556,7 @@ def uri2fsn(uri):
             path += unquote(rest)
         else:
             path += unquote(rest, encoding="utf-8", errors="surrogatepass")
-        if netloc:
+        if netloc or parsed_path.startswith("//"):
             path = "\\\\" + path
         if PY2:
             path = path.decode("utf-8")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1030,6 +1030,10 @@ def test_uri2fsn():
         assert uri2fsn(u"file://UNC/foo/bar") == u"\\\\UNC\\foo\\bar"
         assert uri2fsn(u"file://\u1234/\u4321") == u"\\\\\u1234\\\u4321"
 
+        # Also handle legacy UNC URIs
+        assert uri2fsn(u"file:////UNC/foo") == u"\\\\UNC\\foo"
+        assert fsn2uri(uri2fsn(u"file:////UNC/foo")) == u"file://UNC/foo"
+
     with pytest.raises(TypeError):
         uri2fsn(object())  # type: ignore
 


### PR DESCRIPTION
Some programs (like glib) generate URIs which have the UNC path
as the URI path part instead of splitting it into host and path.

Handle those cases by assuming that paths starting with // are
UNC URIs.