### PR TITLE
expanduser: Ignore HOME env var on Windows

### DIFF
--- a/senf/_stdlib.py
+++ b/senf/_stdlib.py
@@ -57,14 +57,14 @@ def _get_userdir(user=None):
         raise TypeError
 
     if is_win:
-        if "HOME" in environ:
-            path = environ["HOME"]
-        elif "USERPROFILE" in environ:
+        if "USERPROFILE" in environ:
             path = environ["USERPROFILE"]
         elif "HOMEPATH" in environ and "HOMEDRIVE" in environ:
             path = os.path.join(environ["HOMEDRIVE"], environ["HOMEPATH"])
         else:
             return
+
+        path = os.path.normpath(path)
 
         if user is None:
             return path

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -202,9 +202,10 @@ def test_getuserdir():
         user = os.path.basename(userdir)
         assert userdir == _get_userdir(user)
 
-    with preserve_environ():
-        environ["HOME"] = "bla"
-        assert _get_userdir() == "bla"
+    if sys.platform != "win32":
+        with preserve_environ():
+            environ["HOME"] = "bla"
+            assert _get_userdir() == "bla"
 
     with preserve_environ():
         environ.pop("HOME", None)
@@ -220,8 +221,8 @@ def test_getuserdir():
         if sys.platform == "win32":
             environ["HOMEPATH"] = "hpath"
             environ["HOMEDRIVE"] = "C:\\"
-            assert _get_userdir() == "C:\\hpath"
-            assert _get_userdir(u"bla") == "C:\\bla"
+            assert _get_userdir() == os.path.join("C:", senf.sep, "hpath")
+            assert _get_userdir(u"bla") == os.path.join("C:", senf.sep, "bla")
 
     with preserve_environ():
         environ.pop("HOME", None)


### PR DESCRIPTION
Python 3.7/8 has started to ignore HOME in expanduser on Windows.

We could try to figure out what the stdlib does and mirror that, but
let's keep it simply and just use the new preferred behaviour in all cases.