### PR TITLE
uri2fsn: fix handling of relative paths with newer Python

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-13, windows-2019]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', 'pypy3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', 'pypy3.10']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest hypothesis flake8 coverage
+        pip install pytest hypothesis flake8 coverage setuptools
     - name: Run tests on Unix
       if: ${{ matrix.os != 'windows-2019' }}
       run: |

--- a/senf/_fsnative.py
+++ b/senf/_fsnative.py
@@ -541,7 +541,11 @@ def uri2fsn(uri):
     if not parsed_path:
         raise ValueError("Invalid file URI: %r" % uri)
 
-    uri = urlunparse(parsed)[7:]
+    uri = urlunparse(parsed)[5:]
+    if not parsed_path.startswith("/") and uri.startswith("/"):
+        uri = uri.lstrip("/")
+    if not netloc and uri.startswith("///"):
+        uri = uri[2:]
 
     if is_win:
         try:
@@ -556,8 +560,6 @@ def uri2fsn(uri):
             path += unquote(rest)
         else:
             path += unquote(rest, encoding="utf-8", errors="surrogatepass")
-        if netloc or parsed_path.startswith("//"):
-            path = "\\\\" + path
         if PY2:
             path = path.decode("utf-8")
         if u"\x00" in path:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1005,7 +1005,7 @@ def test_uri2fsn():
         assert isinstance(uri2fsn(u"file:///foo"), fsnative)
         assert \
             uri2fsn("file:///foo-%E1%88%B4") == path2fsn(b"/foo-\xe1\x88\xb4")
-        assert uri2fsn("file:NOPE") == fsnative(u"/NOPE")
+        assert uri2fsn("file:NOPE") == fsnative(u"NOPE")
         assert uri2fsn("file:/NOPE") == fsnative(u"/NOPE")
         with pytest.raises(ValueError):
             assert uri2fsn("file://NOPE")
@@ -1015,7 +1015,7 @@ def test_uri2fsn():
     else:
         assert uri2fsn("file:///C:/%ED%A0%80") == fsnative(u"C:\\\ud800")
         assert uri2fsn("file:///C:/%20") == "C:\\ "
-        assert uri2fsn("file:NOPE") == "\\NOPE"
+        assert uri2fsn("file:NOPE") == "NOPE"
         assert uri2fsn("file:/NOPE") == "\\NOPE"
         with pytest.raises(ValueError):
             assert uri2fsn(u"file:///C:/%00")


### PR DESCRIPTION
Python 3.12 changed urlunparse() results for relative file uris as a side
effect of some other changes. It's not clear what and why from the
git history, so try to reproduce the new behaviour for all Python
versions (if path doesn't start with / then strip them from the result).

And since urlunparse() is no longer guaranteed to return uris starting
// move the netloc hack up to simplify things.

tbh I'm a bit out of the loop re URIs, so I hope on the test coverage
to prevent any oversights.

Fixes https://github.com/quodlibet/senf/issues/16